### PR TITLE
feat: show rotate device message for portrait

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,8 +38,8 @@
 
         <div id="rotateOverlay" class="overlay rotate-center" style="display:none">
           <div class="rotate-box">
-            <h2>Bitte Gerät drehen</h2>
-            <p>Das Spiel funktioniert nur im <b>Querformat</b>.</p>
+            <h2>Turn your device</h2>
+            <p>This game works best in <b>landscape mode</b>.</p>
           </div>
         </div>
 

--- a/js/game.js
+++ b/js/game.js
@@ -63,10 +63,12 @@ function toggleFullscreen(){
 }
 
 function checkOrientation(){
-  let portrait = window.innerHeight > window.innerWidth;
-  document.getElementById('rotateOverlay').style.display = portrait ? 'flex' : 'none';
-  document.getElementById('stage').style.visibility = portrait ? 'hidden' : 'visible';
+  const portrait = window.matchMedia('(orientation: portrait)').matches;
+  const overlay = document.getElementById('rotateOverlay');
+  if (overlay) overlay.style.display = portrait ? 'flex' : 'none';
 }
+
+window.addEventListener('orientationchange', checkOrientation);
 
 function setKey(key, val){
   if(world && world.keyboard) world.keyboard[key] = val;


### PR DESCRIPTION
## Summary
- show "Turn your device" overlay for portrait orientation
- use `matchMedia` and orientationchange to toggle the overlay
- ensure the overlay is visible by keeping the stage displayed

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c6520cb48325abfbceee89b56025