### PR TITLE
Show orientation warning on mobile devices

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -65,7 +65,10 @@ function toggleFullscreen(){
 function checkOrientation(){
   const portrait = window.matchMedia('(orientation: portrait)').matches;
   const overlay = document.getElementById('rotateOverlay');
+  const isMobile = /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
 
+  if(!overlay) return;
+  overlay.style.display = portrait && isMobile ? 'flex' : 'none';
 }
 
 window.addEventListener('orientationchange', checkOrientation);

--- a/style.css
+++ b/style.css
@@ -139,8 +139,6 @@ font-size: 0;
 
 @media (orientation:portrait){
   html, body{ overflow:hidden; height:100%; }
-  #stage{ display:none; }
-  #rotateOverlay{ display:flex; }
 }
 
 @media (max-width:1024px) and (orientation:landscape){
@@ -186,8 +184,3 @@ font-size: 0;
   html, body{ overflow:hidden; height:100%; }
 }
 
-@media (orientation:portrait){
-  html, body{ overflow:hidden; height:100%; }
-  #stage{ display:none; }
-  #rotateOverlay{ display:flex; }
-}


### PR DESCRIPTION
## Summary
- Ensure the "Turn your device" overlay appears only on mobile devices in portrait orientation
- Simplify portrait CSS rule so the stage remains visible for the overlay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7cb059abc8325aed81ad3062cfb30