### PR TITLE
Improve rotate overlay visibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -74,6 +74,10 @@ border-radius: 8px;
   object-fit: contain; display: block; background: #000; z-index: 4;
 }
 
+#rotateOverlay{
+  background: rgba(0,0,0,.8);
+}
+
 .hud-btn{
   position: absolute; right: 16px; bottom: 16px;
   width:36px; height:36px; border:none; border-radius:9999px;
@@ -93,7 +97,7 @@ border-radius: 8px;
 .close-btn{ margin-top:10px; width:100%; border:none; border-radius:8px; padding:8px 10px; background:#ffd700; color:#000; font-weight:700; cursor:pointer; }
 
 .rotate-center{ display:flex; align-items:center; justify-content:center; }
-.rotate-box{ font-family: Arial, Helvetica, sans-serif; text-align:center; background:rgba(0,0,0,.55); padding:16px 20px; border-radius:10px; }
+.rotate-box{ font-family: Arial, Helvetica, sans-serif; text-align:center; background:rgba(0,0,0,.55); padding:16px 20px; border-radius:10px; color:#fff; }
 .rotate-box h2{ margin:0 0 6px; font-size:20px; }
 .rotate-box p{ margin:0; font-size:14px; }
 


### PR DESCRIPTION
## Summary
- highlight "Turn your device" notice with semi-transparent overlay
- switch rotate dialog text to white for better contrast

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7cecaac348325936464ca03fe25e2