### PR TITLE
Show enemy death animations

### DIFF
--- a/models/chicken-small.class.js
+++ b/models/chicken-small.class.js
@@ -19,8 +19,9 @@ this.animate();
 
 
 die(){
-this.alive=false; this.speed=0;
-this.playAnimation(this.IMAGES_DEAD);
+ this.alive=false; this.speed=0;
+ this.deadTime = Date.now();
+ this.playAnimation(this.IMAGES_DEAD);
 }
 
 

--- a/models/chicken.class.js
+++ b/models/chicken.class.js
@@ -26,8 +26,9 @@ setInterval(()=>{ if(this.alive) this.playAnimation(this.IMAGES_WALKING); }, 200
 
 
 die(){
-this.alive = false;
-this.playAnimation(this.IMAGES_DEAD);
+ this.alive = false;
+ this.deadTime = Date.now();
+ this.playAnimation(this.IMAGES_DEAD);
 }
 }
 

--- a/models/endboss.class.js
+++ b/models/endboss.class.js
@@ -19,9 +19,14 @@ class Endboss extends MovableObject {
     'img/4_enemie_boss_chicken/1_walk/G3.png',
     'img/4_enemie_boss_chicken/1_walk/G4.png',
   ];
+  IMAGES_DEAD = [
+    'img/4_enemie_boss_chicken/5_dead/G24.png',
+    'img/4_enemie_boss_chicken/5_dead/G25.png',
+    'img/4_enemie_boss_chicken/5_dead/G26.png'
+  ];
 
  constructor(){ super().loadImage(this.IMAGES_WALK[0]);
-    this.loadImages(this.IMAGES_INTRO); this.loadImages(this.IMAGES_WALK);
+    this.loadImages(this.IMAGES_INTRO); this.loadImages(this.IMAGES_WALK); this.loadImages(this.IMAGES_DEAD);
     this.x=2500;
   }
 
@@ -30,8 +35,18 @@ class Endboss extends MovableObject {
     this.hp -= d; if(this.hp<=0) this.die();
   }
 
-  die(){ this.alive=false; this.speed=0; clearInterval(this._moveInt);
-    clearInterval(this._animInt); }
+  die(){
+    this.alive=false; this.speed=0; this.deadTime = Date.now();
+    clearInterval(this._moveInt); clearInterval(this._animInt);
+    let i=0;
+    this._deathInt = setInterval(()=>{
+      if(i<this.IMAGES_DEAD.length){
+        this.img = this.imageCache[this.IMAGES_DEAD[i]]; i++;
+      } else {
+        clearInterval(this._deathInt); showYouWon();
+      }
+    },200);
+  }
 
   
   startIntro() {
@@ -62,10 +77,4 @@ class Endboss extends MovableObject {
       self.playAnimation(self.IMAGES_WALK);
     }, 180);
   }
-die(){
-  this.alive=false; this.speed=0;
-  clearInterval(this._moveInt); clearInterval(this._animInt);
-  showYouWon();
-}
-
 }

--- a/models/world.class.js
+++ b/models/world.class.js
@@ -136,8 +136,13 @@ draw() {
 }
 
 addObjectsToMap(objs){
+  const now = Date.now();
   for(let i=0;i<objs.length;i++){
-    let o=objs[i]; if(!o || o.alive===false || o.broken) continue; 
+    let o=objs[i];
+    if(!o || o.broken) continue;
+    if(o.alive===false){
+      if(!o.deadTime || now - o.deadTime > 1000) continue;
+    }
     this.addToMap(o);
   }
 }


### PR DESCRIPTION
## Summary
- Render dead chickens and chicks using new deadTime and world rendering
- Add endboss death animation sequence and keep enemies visible briefly after death
- Render dead enemies for a short period after defeat

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d0dfb3c88325a3bc941f6b47b630