### PR TITLE
Fix missing bottle generation in level setup

### DIFF
--- a/levels/level1.js
+++ b/levels/level1.js
@@ -47,7 +47,7 @@ function initLevel() {
   enemies.push(spawnEndbossAt(4000));
 
   const backgrounds = buildBackground(bgConfig);
-
+  const bottles = buildBottles(60, 500, 3500);
   level1 = new Level(enemies, [ new Cloud() ], backgrounds, bottles);
   level1.level_end_x = bgConfig.endX;
 }


### PR DESCRIPTION
## Summary
- generate bottles for level 1 to avoid undefined references

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7db3947b88325bec495be87e24408