### PR TITLE
Add Tabasco and boss status bars and smoother Pepe animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
     <script src="models/chicken-small.class.js"></script>
     <script src="models/cloud.class.js"></script>
     <script src="models/status-bar.class.js"></script>
+    <script src="models/status-bar-bottle.class.js"></script>
+    <script src="models/status-bar-endboss.class.js"></script>
     <script src="models/world.class.js"></script>
     <script src="models/background-object.class.js"></script>
     <script src="models/keyboard.class.js"></script>

--- a/models/character.class.js
+++ b/models/character.class.js
@@ -42,8 +42,35 @@ IMAGES_HURT = [
 'img/2_character_pepe/4_hurt/H-43.png'
 ];
 
+IMAGES_IDLE = [
+  'img/2_character_pepe/1_idle/idle/I-1.png',
+  'img/2_character_pepe/1_idle/idle/I-2.png',
+  'img/2_character_pepe/1_idle/idle/I-3.png',
+  'img/2_character_pepe/1_idle/idle/I-4.png',
+  'img/2_character_pepe/1_idle/idle/I-5.png',
+  'img/2_character_pepe/1_idle/idle/I-6.png',
+  'img/2_character_pepe/1_idle/idle/I-7.png',
+  'img/2_character_pepe/1_idle/idle/I-8.png',
+  'img/2_character_pepe/1_idle/idle/I-9.png',
+  'img/2_character_pepe/1_idle/idle/I-10.png'
+];
+
+IMAGES_LONG_IDLE = [
+  'img/2_character_pepe/1_idle/long_idle/I-11.png',
+  'img/2_character_pepe/1_idle/long_idle/I-12.png',
+  'img/2_character_pepe/1_idle/long_idle/I-13.png',
+  'img/2_character_pepe/1_idle/long_idle/I-14.png',
+  'img/2_character_pepe/1_idle/long_idle/I-15.png',
+  'img/2_character_pepe/1_idle/long_idle/I-16.png',
+  'img/2_character_pepe/1_idle/long_idle/I-17.png',
+  'img/2_character_pepe/1_idle/long_idle/I-18.png',
+  'img/2_character_pepe/1_idle/long_idle/I-19.png',
+  'img/2_character_pepe/1_idle/long_idle/I-20.png'
+];
+
 
 world;
+lastMoveTime = 0;
 
 
 constructor() {
@@ -52,42 +79,53 @@ this.loadImages(this.IMAGES_WALKING);
 this.loadImages(this.IMAGES_JUMPING);
 this.loadImages(this.IMAGES_DEAD);
 this.loadImages(this.IMAGES_HURT);
+this.loadImages(this.IMAGES_IDLE);
+this.loadImages(this.IMAGES_LONG_IDLE);
 this.applyGravity();
 }
 
 
 animate() {
-setInterval(() => {
-if (this.world.keyboard.RIGHT && this.x < this.world.level.level_end_x) {
-this.moveRight();
-this.otherDirection = false;
-}
-if (this.world.keyboard.LEFT && this.x > 0) {
-this.moveLeft();
-this.otherDirection = true;
-}
-if (this.world.keyboard.SPACE && !this.isAboveGround()) {
-this.jump();
-}
-if (!this.world.bossFocus) {
-this.world.camera_x = -this.x + 100;
-}
-}, 1000 / 60);
+  setInterval(() => {
+    let moving = false;
+    if (this.world.keyboard.RIGHT && this.x < this.world.level.level_end_x) {
+      this.moveRight();
+      this.otherDirection = false;
+      moving = true;
+    }
+    if (this.world.keyboard.LEFT && this.x > 0) {
+      this.moveLeft();
+      this.otherDirection = true;
+      moving = true;
+    }
+    if (this.world.keyboard.SPACE && !this.isAboveGround()) {
+      this.jump();
+      moving = true;
+    }
+    if (moving) this.lastMoveTime = Date.now();
+    if (!this.world.bossFocus) {
+      this.world.camera_x = -this.x + 100;
+    }
+  }, 1000 / 60);
 
-
-setInterval(() => {
-if (this.isDead()) {
-this.playAnimation(this.IMAGES_DEAD);
-} else if (this.isHurt()) {
-this.playAnimation(this.IMAGES_HURT);
-} else if (this.isAboveGround()) {
-this.playAnimation(this.IMAGES_JUMPING);
-} else {
-if (this.world.keyboard.RIGHT || this.world.keyboard.LEFT) {
-this.playAnimation(this.IMAGES_WALKING);
-}
-}
-}, 50);
+  setInterval(() => {
+    if (this.isDead()) {
+      this.playAnimation(this.IMAGES_DEAD);
+    } else if (this.isHurt()) {
+      this.playAnimation(this.IMAGES_HURT);
+    } else if (this.isAboveGround()) {
+      this.playAnimation(this.IMAGES_JUMPING);
+    } else if (this.world.keyboard.RIGHT || this.world.keyboard.LEFT) {
+      this.playAnimation(this.IMAGES_WALKING);
+    } else {
+      let idleTime = Date.now() - this.lastMoveTime;
+      if (idleTime > 5000) {
+        this.playAnimation(this.IMAGES_LONG_IDLE);
+      } else {
+        this.playAnimation(this.IMAGES_IDLE);
+      }
+    }
+  }, 1000 / 60);
 }
 
 

--- a/models/status-bar-bottle.class.js
+++ b/models/status-bar-bottle.class.js
@@ -1,0 +1,20 @@
+class StatusBarBottle extends StatusBar {
+  IMAGES = [
+    'img/7_statusbars/1_statusbar/3_statusbar_bottle/green/0.png',
+    'img/7_statusbars/1_statusbar/3_statusbar_bottle/green/20.png',
+    'img/7_statusbars/1_statusbar/3_statusbar_bottle/green/40.png',
+    'img/7_statusbars/1_statusbar/3_statusbar_bottle/green/60.png',
+    'img/7_statusbars/1_statusbar/3_statusbar_bottle/green/80.png',
+    'img/7_statusbars/1_statusbar/3_statusbar_bottle/green/100.png'
+  ];
+
+  constructor() {
+    super();
+    this.loadImages(this.IMAGES);
+    this.x = 40;
+    this.y = 40;
+    this.width = 200;
+    this.height = 60;
+    this.setPercentage(0);
+  }
+}

--- a/models/status-bar-endboss.class.js
+++ b/models/status-bar-endboss.class.js
@@ -1,0 +1,21 @@
+class StatusBarEndboss extends StatusBar {
+  IMAGES = [
+    'img/7_statusbars/2_statusbar_endboss/green/green0.png',
+    'img/7_statusbars/2_statusbar_endboss/green/green20.png',
+    'img/7_statusbars/2_statusbar_endboss/green/green40.png',
+    'img/7_statusbars/2_statusbar_endboss/green/green60.png',
+    'img/7_statusbars/2_statusbar_endboss/green/green80.png',
+    'img/7_statusbars/2_statusbar_endboss/green/green100.png'
+  ];
+
+  constructor() {
+    super();
+    this.loadImages(this.IMAGES);
+    this.x = 500;
+    this.y = 0;
+    this.width = 200;
+    this.height = 60;
+    this.setPercentage(100);
+    this.visible = false;
+  }
+}

--- a/models/world.class.js
+++ b/models/world.class.js
@@ -6,6 +6,8 @@ class World {
   keyboard;
   camera_x = 0; bossFocus = false;
   statusBar = new StatusBar();
+  bottleBar = new StatusBarBottle();
+  bossBar = new StatusBarEndboss();
   throwableObjects = [];
   bottleCount = 0;
 
@@ -35,11 +37,14 @@ isStomp(c,e){
   return c.speedY < 0 && c.y < e.y && c.isAboveGround();
 }
 
-hitEnemy(e,d){ 
-  if(!e || !e.alive) return;
-  if(e.takeDamage) e.takeDamage(d);
-  else { e.hp = (e.hp||1)-d; if(e.hp<=0 && e.die) e.die(); }
-}
+  hitEnemy(e,d){
+    if(!e || !e.alive) return;
+    if(e.takeDamage) e.takeDamage(d);
+    else { e.hp = (e.hp||1)-d; if(e.hp<=0 && e.die) e.die(); }
+    if(e instanceof Endboss && this.bossBar){
+      this.bossBar.setPercentage(Math.max(e.hp,0) * 20);
+    }
+  }
 
 hitPlayer(d){ 
   if(this.character && this.character.hit) this.character.hit();
@@ -67,6 +72,7 @@ run(){
       );
       this.throwableObjects.push(b);
       this.bottleCount--;
+      this.bottleBar.setPercentage(Math.min(this.bottleCount,5) * 20);
       this.keyboard.D = false;
     }
   }
@@ -79,6 +85,7 @@ run(){
       if(this.isColliding(this.character, bo)){
         bo.collect();
         this.bottleCount++;
+        this.bottleBar.setPercentage(Math.min(this.bottleCount,5) * 20);
       }
     }
   }
@@ -125,6 +132,8 @@ checkBottleHits(){
       if (e instanceof Endboss && !e.hadFirstContact) {
         if (this.character.x > e.x - 600) {
           e.startIntro();
+          this.bossBar.visible = true;
+          this.bossBar.setPercentage(e.hp * 20);
           this.bossFocus = true;
           this.camera_x = -(e.x - 200);
           setTimeout(() => {
@@ -154,6 +163,10 @@ draw() {
   this.addObjectsToMap(this.level.backgroundObjects);
   this.ctx.translate(-cam,0);
   this.addToMap(this.statusBar);
+  this.addToMap(this.bottleBar);
+  if (this.bossBar.visible) {
+    this.addToMap(this.bossBar);
+  }
   this.ctx.translate(cam,0);
   this.addToMap(this.character);
   this.addObjectsToMap(this.level.clouds);


### PR DESCRIPTION
## Summary
- Show bottle and endboss status bars with dynamic updates
- Use full idle and long-idle animations for smoother character motion
- Update world logic to manage new UI elements

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7de0fe6088325af68e83a09c48acd