### PR TITLE
Adjust character animation and enemy balance

### DIFF
--- a/models/character.class.js
+++ b/models/character.class.js
@@ -108,6 +108,7 @@ animate() {
     }
   }, 1000 / 60);
 
+  // slow down animation cycle to avoid jittering
   setInterval(() => {
     if (this.isDead()) {
       this.playAnimation(this.IMAGES_DEAD);
@@ -125,7 +126,7 @@ animate() {
         this.playAnimation(this.IMAGES_IDLE);
       }
     }
-  }, 1000 / 60);
+  }, 100);
 }
 
 

--- a/models/endboss.class.js
+++ b/models/endboss.class.js
@@ -1,7 +1,7 @@
 class Endboss extends MovableObject {
   hadFirstContact=false; isIntro=false;
-  height=400; width=250; y=55; speed=0.4;
-  hp=5; damage=30; alive=true; 
+  height=400; width=250; y=55; speed=0.6;
+  maxHp=8; hp=8; damage=30; alive=true;
 
   IMAGES_INTRO = [
     'img/4_enemie_boss_chicken/2_alert/G5.png',

--- a/models/world.class.js
+++ b/models/world.class.js
@@ -34,7 +34,9 @@ class World {
 }
 
 isStomp(c,e){
-  return c.speedY < 0 && c.y < e.y && c.isAboveGround();
+  const charBottom = c.y + c.height;
+  const enemyMid = e.y + e.height / 2;
+  return c.speedY < 0 && charBottom < enemyMid;
 }
 
   hitEnemy(e,d){
@@ -42,7 +44,7 @@ isStomp(c,e){
     if(e.takeDamage) e.takeDamage(d);
     else { e.hp = (e.hp||1)-d; if(e.hp<=0 && e.die) e.die(); }
     if(e instanceof Endboss && this.bossBar){
-      this.bossBar.setPercentage(Math.max(e.hp,0) * 20);
+      this.bossBar.setPercentage(Math.max(e.hp,0) / e.maxHp * 100);
     }
   }
 
@@ -133,7 +135,7 @@ checkBottleHits(){
         if (this.character.x > e.x - 600) {
           e.startIntro();
           this.bossBar.visible = true;
-          this.bossBar.setPercentage(e.hp * 20);
+          this.bossBar.setPercentage(e.hp / e.maxHp * 100);
           this.bossFocus = true;
           this.camera_x = -(e.x - 200);
           setTimeout(() => {


### PR DESCRIPTION
## Summary
- slow Pepe's animation playback to prevent jitter
- allow stomping chickens more easily by relaxing collision check
- toughen endboss with higher HP and slightly faster movement, update boss bar to new max HP

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e0c9d3648325b3ba11d06a8eafe2