### PR TITLE
Improve enemy interactions and restart flow

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -83,8 +83,13 @@ function release(key, el){ if(el) el.removeAttribute('data-active'); setKey(key,
 
 function resetGame(){
   ['gameOverOverlay','youWonOverlay','startOverlay'].forEach(id=>{ let el=document.getElementById(id); if(el) el.style.display='none'; });
+  let ui=document.getElementById('startUI'); if(ui) ui.style.display='none';
+  if(world && world.stop) world.stop();
+  keyboard = new Keyboard();
   if(canvas){ let ctx=canvas.getContext('2d'); ctx.clearRect(0,0,canvas.width,canvas.height); }
-  location.reload();
+  init();
+  checkOrientation();
+  focusCanvas();
 }
 
 // expose function for inline button handlers

--- a/models/throwable-object.class.js
+++ b/models/throwable-object.class.js
@@ -11,10 +11,10 @@ class ThrowableObject extends MovableObject {
   }
 
 trow(){
-  this.speedY = 15;
-  this.acceleration = 2.2;
+  this.speedY = 20;
+  this.acceleration = 2.5;
   this.applyGravity();
-  let vx = 12 * this.dir;
-  setInterval(()=>{ this.x += vx; }, 25);
+  let vx = 10 * this.dir;
+  setInterval(()=>{ this.x += vx; }, 1000/60);
 }
 }

--- a/models/world.class.js
+++ b/models/world.class.js
@@ -35,8 +35,11 @@ class World {
 
 isStomp(c,e){
   const charBottom = c.y + c.height;
-  const enemyMid = e.y + e.height / 2;
-  return c.speedY < 0 && charBottom < enemyMid;
+  let limit = e.y + e.height / 2;
+  if(e instanceof SmallChicken){
+    limit = e.y + e.height;
+  }
+  return c.speedY < 0 && charBottom < limit;
 }
 
   hitEnemy(e,d){
@@ -54,14 +57,14 @@ hitPlayer(d){
 }
 
 run(){
-  setInterval(()=>{
+  this.runInterval = setInterval(()=>{
     this.checkCollisions();
     this.checkBottleHits();
-    this.checkThrowObjects();
     this.checkBottlePickups();
     this.checkEndbossIntro();
     this.checkGameOver();
   },200);
+  this.throwInterval = setInterval(()=>{ this.checkThrowObjects(); }, 1000/60);
 }
 
   checkThrowObjects() {
@@ -117,7 +120,7 @@ checkCollisions(){
   }
 }
 
-checkBottleHits(){ 
+  checkBottleHits(){
   for(let i=0;i<this.throwableObjects.length;i++){
     let t=this.throwableObjects[i]; if(!t || t.broken) continue;
     for(let j=0;j<this.level.enemies.length;j++){
@@ -159,8 +162,9 @@ checkBottleHits(){
 
 
 draw() {
+  if(this.isStopped) return;
   this.ctx.clearRect(0,0,this.canvas.width,this.canvas.height);
-  const cam = Math.round(this.camera_x); 
+  const cam = Math.round(this.camera_x);
   this.ctx.translate(cam,0);
   this.addObjectsToMap(this.level.backgroundObjects);
   this.ctx.translate(-cam,0);
@@ -206,5 +210,11 @@ addObjectsToMap(objs){
   flipImageBack(mo) {
     mo.x *= -1;
     this.ctx.restore();
+  }
+
+  stop(){
+    this.isStopped = true;
+    if(this.runInterval) clearInterval(this.runInterval);
+    if(this.throwInterval) clearInterval(this.throwInterval);
   }
 }


### PR DESCRIPTION
## Summary
- Allow stomping yellow small chickens to trigger their death animation.
- Make bottle throwing more responsive with faster, smoother projectiles.
- Restart button now immediately starts a fresh round without showing the start screen.

## Testing
- ⚠️ `node -v` *(Node not installed)*
- ⚠️ `npm test` *(npm missing)*


------
https://chatgpt.com/codex/tasks/task_e_68c7e300f3488325a2a51d1289f88e9d