### PR TITLE
Balance boss and projectile mechanics

### DIFF
--- a/models/chicken-small.class.js
+++ b/models/chicken-small.class.js
@@ -1,6 +1,6 @@
 class SmallChicken extends MovableObject {
 y = 390; height = 45; width = 50;
-hp = 1; damage = 10; alive = true;
+hp = 3; damage = 10; alive = true;
 IMAGES_WALKING = [
 'img/3_enemies_chicken/chicken_small/1_walk/1_w.png',
 'img/3_enemies_chicken/chicken_small/1_walk/2_w.png',

--- a/models/endboss.class.js
+++ b/models/endboss.class.js
@@ -1,7 +1,7 @@
 class Endboss extends MovableObject {
-  hadFirstContact=false; isIntro=false;
+  hadFirstContact=false; isIntro=false; aggressive=false;
   height=400; width=250; y=55; speed=0.6;
-  maxHp=8; hp=8; damage=30; alive=true;
+  maxHp=9; hp=9; damage=30; alive=true;
 
   IMAGES_INTRO = [
     'img/4_enemie_boss_chicken/2_alert/G5.png',
@@ -19,6 +19,16 @@ class Endboss extends MovableObject {
     'img/4_enemie_boss_chicken/1_walk/G3.png',
     'img/4_enemie_boss_chicken/1_walk/G4.png',
   ];
+  IMAGES_ATTACK = [
+    'img/4_enemie_boss_chicken/3_attack/G13.png',
+    'img/4_enemie_boss_chicken/3_attack/G14.png',
+    'img/4_enemie_boss_chicken/3_attack/G15.png',
+    'img/4_enemie_boss_chicken/3_attack/G16.png',
+    'img/4_enemie_boss_chicken/3_attack/G17.png',
+    'img/4_enemie_boss_chicken/3_attack/G18.png',
+    'img/4_enemie_boss_chicken/3_attack/G19.png',
+    'img/4_enemie_boss_chicken/3_attack/G20.png'
+  ];
   IMAGES_DEAD = [
     'img/4_enemie_boss_chicken/5_dead/G24.png',
     'img/4_enemie_boss_chicken/5_dead/G25.png',
@@ -26,13 +36,15 @@ class Endboss extends MovableObject {
   ];
 
  constructor(){ super().loadImage(this.IMAGES_WALK[0]);
-    this.loadImages(this.IMAGES_INTRO); this.loadImages(this.IMAGES_WALK); this.loadImages(this.IMAGES_DEAD);
+    this.loadImages(this.IMAGES_INTRO); this.loadImages(this.IMAGES_WALK); this.loadImages(this.IMAGES_ATTACK); this.loadImages(this.IMAGES_DEAD);
     this.x=2500;
-  }
+ }
 
-  takeDamage(d){ 
+  takeDamage(d){
     if(!this.alive) return;
-    this.hp -= d; if(this.hp<=0) this.die();
+    this.hp -= d;
+    if(this.hp <= 3 && !this.aggressive) this.becomeAggressive();
+    if(this.hp<=0) this.die();
   }
 
   die(){
@@ -76,5 +88,23 @@ class Endboss extends MovableObject {
     this._animInt = setInterval(function () {
       self.playAnimation(self.IMAGES_WALK);
     }, 180);
+  }
+
+  becomeAggressive(){
+    this.aggressive = true;
+    clearInterval(this._moveInt);
+    clearInterval(this._animInt);
+    this.speed = 1.2;
+    this.startAttack();
+  }
+
+  startAttack(){
+    let self = this;
+    this._moveInt = setInterval(function(){
+      self.moveLeft();
+    },1000/60);
+    this._animInt = setInterval(function(){
+      self.playAnimation(self.IMAGES_ATTACK);
+    },120);
   }
 }

--- a/models/throwable-object.class.js
+++ b/models/throwable-object.class.js
@@ -7,7 +7,7 @@ class ThrowableObject extends MovableObject {
     this.height = 60;
     this.width = 50;
     this.dir = dir || 1;
-    this.speed = 10;
+    this.speed = 8;
     this.trow();
   }
 
@@ -35,9 +35,16 @@ trow(){
       let dx = (target.x + target.width/2) - (this.x + this.width/2);
       let dy = (target.y + target.height/2) - (this.y + this.height/2);
       let dist = Math.sqrt(dx*dx + dy*dy);
-      if(dist){
-        this.x += (dx/dist) * this.speed;
-        this.y += (dy/dist) * this.speed;
+      if(dist < 350){
+        dx += (Math.random()-0.5) * 100;
+        dy += (Math.random()-0.5) * 100;
+        dist = Math.sqrt(dx*dx + dy*dy);
+        if(dist){
+          this.x += (dx/dist) * this.speed;
+          this.y += (dy/dist) * this.speed;
+        }
+      } else {
+        this.x += this.dir * this.speed;
       }
     } else {
       this.x += this.dir * this.speed;

--- a/models/world.class.js
+++ b/models/world.class.js
@@ -34,7 +34,7 @@ class World {
 }
 
 isStomp(c,e){
-  return c.speedY < 0;
+  return c.speedY < -5;
 }
 
   hitEnemy(e,d){
@@ -120,7 +120,7 @@ checkCollisions(){
     let t=this.throwableObjects[i]; if(!t || t.broken) continue;
     for(let j=0;j<this.level.enemies.length;j++){
       let e=this.level.enemies[j]; if(!e || !e.alive) continue;
-      if(this.isColliding(t,e)){ this.hitEnemy(e, e.hp||1); t.broken=true; break; }
+      if(this.isColliding(t,e)){ this.hitEnemy(e,1); t.broken=true; break; }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Increase endboss health to nine hits and introduce an aggressive attack phase with new animation and speed boost.
- Weaken auto-aim: bottles travel slower, only home within a radius and include random deviation.
- Small chickens gain extra health; walking over them only hurts the player, while bottles deal only one damage.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e79998648325a7fc09ac556ba0a0