### PR TITLE
Require stomping from above to defeat enemies

### DIFF
--- a/models/world.class.js
+++ b/models/world.class.js
@@ -34,7 +34,12 @@ class World {
 }
 
 isStomp(c,e){
-  return c.speedY < -5;
+  // A stomp only counts when the player is falling and their feet
+  // are above the enemy. This prevents running into enemies from
+  // the side from defeating them instantly.
+  const falling = c.speedY < 0;
+  const above = (c.y + c.height) - e.y < 15;
+  return falling && above;
 }
 
   hitEnemy(e,d){


### PR DESCRIPTION
## Summary
- Only allow defeating enemies when Pepe is falling from above, preventing side collisions from instantly killing foes.

## Testing
- `npm test` *(fails: command not found: npm)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e9280f288325a912f167545aa9eb