### PR TITLE
Fix start mute and overlapping audio

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,6 @@
     <main>
       <div id="stage">
         <canvas id="canvas" width="720" height="480" tabindex="0"></canvas>
-        <audio id="bgMusic" src="audio/start.ogg" loop muted></audio>
 
         <img id="startOverlay" class="overlay" src="img/9_intro_outro_screens/start/startscreen_1.png" alt="Startscreen" />
 
@@ -61,7 +60,7 @@
                   aria-label="Fullscreen">⛶</button>
                   <button id="muteBtn" class="hud-btn" tabindex="-1"
                   onclick="toggleMute()" onmousedown="return blurToCanvas(this)"
-                  aria-label="Ton umschalten">🔇</button>
+                  aria-label="Ton umschalten">🔊</button>
           <button id="infoBtn" class="hud-btn" tabindex="-1"
                   onclick="toggleInfo()" onmousedown="return blurToCanvas(this)"
                   aria-label="Info">i</button>

--- a/js/game.js
+++ b/js/game.js
@@ -1,13 +1,13 @@
 let canvas;
 let world;
 let keyboard = new Keyboard();
-let bgMusic;
 
 const audioStart = new Audio('audio/start.ogg');
 const audioGame = new Audio('audio/game.mp3');
 const audioWin = new Audio('audio/win.mp3');
 const audioGameOver = new Audio('audio/gameover.mp3');
-[audioStart, audioGame, audioWin, audioGameOver].forEach(a=>{a.volume=0.2;});
+const sounds = [audioStart, audioGame, audioWin, audioGameOver];
+sounds.forEach(a=>{a.volume=0.2;});
 audioStart.loop = true;
 audioGame.loop = true;
 
@@ -28,7 +28,8 @@ function showStart(){
   document.getElementById('startUI').style.display = 'grid';
   checkOrientation();
   audioStart.currentTime = 0;
-  audioStart.play();
+  audioStart.play().catch(()=>{});
+  updateMuteButton();
 }
 
 function init(){
@@ -55,9 +56,7 @@ function startGame(){
   audioStart.pause();
   audioStart.currentTime = 0;
   audioGame.currentTime = 0;
-  audioGame.play();
-  if(!bgMusic) bgMusic = document.getElementById('bgMusic');
-  if(bgMusic) bgMusic.play().catch(()=>{});
+  audioGame.play().catch(()=>{});
 }
 
 document.onfullscreenchange = function(){
@@ -90,12 +89,15 @@ function checkOrientation(){
 
 window.addEventListener('orientationchange', checkOrientation);
 
-function toggleMute(){
-  if(!bgMusic) bgMusic = document.getElementById('bgMusic');
-  if(!bgMusic) return;
-  bgMusic.muted = !bgMusic.muted;
+function updateMuteButton(){
   let btn=document.getElementById('muteBtn');
-  if(btn) btn.innerText = bgMusic.muted ? '🔇' : '🔊';
+  if(btn) btn.innerText = audioStart.muted ? '🔇' : '🔊';
+}
+
+function toggleMute(){
+  const mute = !audioStart.muted;
+  sounds.forEach(a=>a.muted = mute);
+  updateMuteButton();
 }
 window.toggleMute = toggleMute;
 
@@ -116,9 +118,8 @@ function resetGame(){
   init();
   checkOrientation();
   focusCanvas();
-  [audioStart, audioWin, audioGameOver].forEach(a=>{a.pause(); a.currentTime=0;});
-  audioGame.currentTime = 0;
-  audioGame.play();
+  sounds.forEach(a=>{a.pause(); a.currentTime=0;});
+  audioGame.play().catch(()=>{});
 }
 
 // expose function for inline button handlers


### PR DESCRIPTION
## Summary
- Remove unused background audio element and show sound-on icon by default
- Consolidate audio handling and ensure mute toggles all sounds to avoid overlapping tracks
- Guard audio playback with Promise catch to suppress console errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f7d4781c8325924faa4da27efda6