### PR TITLE
Refactor long methods into smaller helpers

### DIFF
--- a/models/character.class.js
+++ b/models/character.class.js
@@ -88,47 +88,72 @@ this.applyGravity();
 
 
 animate() {
-  setInterval(() => {
-    let moving = false;
-    if (this.world.keyboard.RIGHT && this.x < this.world.level.level_end_x) {
-      this.moveRight();
-      this.otherDirection = false;
-      moving = true;
-    }
-    if (this.world.keyboard.LEFT && this.x > 0) {
-      this.moveLeft();
-      this.otherDirection = true;
-      moving = true;
-    }
-    if (this.world.keyboard.SPACE && !this.isAboveGround()) {
-      this.jump();
-      moving = true;
-    }
-    if (moving) this.lastMoveTime = Date.now();
-    if (!this.world.bossFocus) {
-      this.world.camera_x = -this.x + 100;
-    }
-  }, 1000 / 60);
+  this.startMovement();
+  this.startAnimationCycle();
+}
 
+startMovement() {
+  setInterval(() => {
+    const moving = this.handleInput();
+    if (moving) this.lastMoveTime = Date.now();
+    if (!this.world.bossFocus) this.world.camera_x = -this.x + 100;
+  }, 1000 / 60);
+}
+
+handleInput() {
+  let moving = false;
+  if (this.handleRight()) moving = true;
+  if (this.handleLeft()) moving = true;
+  if (this.handleJump()) moving = true;
+  return moving;
+}
+
+handleRight() {
+  if (this.world.keyboard.RIGHT && this.x < this.world.level.level_end_x) {
+    this.moveRight();
+    this.otherDirection = false;
+    return true;
+  }
+  return false;
+}
+
+handleLeft() {
+  if (this.world.keyboard.LEFT && this.x > 0) {
+    this.moveLeft();
+    this.otherDirection = true;
+    return true;
+  }
+  return false;
+}
+
+handleJump() {
+  if (this.world.keyboard.SPACE && !this.isAboveGround()) {
+    this.jump();
+    return true;
+  }
+  return false;
+}
+
+startAnimationCycle() {
   // slow down animation cycle to avoid jittering
   setInterval(() => {
-    if (this.isDead()) {
-      this.playAnimation(this.IMAGES_DEAD);
-    } else if (this.isHurt()) {
-      this.playAnimation(this.IMAGES_HURT);
-    } else if (this.isAboveGround()) {
-      this.playAnimation(this.IMAGES_JUMPING);
-    } else if (this.world.keyboard.RIGHT || this.world.keyboard.LEFT) {
-      this.playAnimation(this.IMAGES_WALKING);
-    } else {
-      let idleTime = Date.now() - this.lastMoveTime;
-      if (idleTime > 5000) {
-        this.playAnimation(this.IMAGES_LONG_IDLE);
-      } else {
-        this.playAnimation(this.IMAGES_IDLE);
-      }
-    }
+    this.playCurrentAnimation();
   }, 100);
+}
+
+playCurrentAnimation() {
+  if (this.isDead()) this.playAnimation(this.IMAGES_DEAD);
+  else if (this.isHurt()) this.playAnimation(this.IMAGES_HURT);
+  else if (this.isAboveGround()) this.playAnimation(this.IMAGES_JUMPING);
+  else if (this.world.keyboard.RIGHT || this.world.keyboard.LEFT)
+    this.playAnimation(this.IMAGES_WALKING);
+  else this.playIdleAnimation();
+}
+
+playIdleAnimation() {
+  let idleTime = Date.now() - this.lastMoveTime;
+  if (idleTime > 5000) this.playAnimation(this.IMAGES_LONG_IDLE);
+  else this.playAnimation(this.IMAGES_IDLE);
 }
 
 

--- a/models/world.class.js
+++ b/models/world.class.js
@@ -106,21 +106,25 @@ run(){
     }
   }
 
-checkCollisions(){ 
-  let es=this.level.enemies; if(!es) return;
-  for(let i=0;i<es.length;i++){
-    let e=es[i]; if(!e||e.alive===false) continue;
-      if(this.isColliding(this.character, e)){
-      if(this.isStomp(this.character, e)){
-        if(e instanceof Chicken || e instanceof SmallChicken){
-          this.hitEnemy(e, e.hp||1);
-        } else {
-          this.hitEnemy(e,1);
-        }
-      } else {
-        this.hitPlayer(e.damage||10);
-      }
-    }
+checkCollisions(){
+  const enemies = this.level.enemies;
+  if (!enemies) return;
+  enemies.forEach(e => {
+    if (!e || e.alive === false) return;
+    if (this.isColliding(this.character, e)) this.resolveCollision(e);
+  });
+}
+
+resolveCollision(e){
+  if(this.isStomp(this.character, e)) this.handleStomp(e);
+  else this.hitPlayer(e.damage||10);
+}
+
+handleStomp(e){
+  if(e instanceof Chicken || e instanceof SmallChicken){
+    this.hitEnemy(e, e.hp||1);
+  } else {
+    this.hitEnemy(e,1);
   }
 }
 
@@ -136,20 +140,21 @@ checkCollisions(){
 
 
   checkEndbossIntro() {
-    for (let i = 0; i < this.level.enemies.length; i++) {
-      let e = this.level.enemies[i];
+    this.level.enemies.forEach(e => {
       if (e instanceof Endboss && !e.hadFirstContact) {
-        if (this.character.x > e.x - 600) {
-          e.startIntro();
-          this.bossBar.visible = true;
-          this.bossBar.setPercentage(e.hp / e.maxHp * 100);
-          this.bossFocus = true;
-          this.camera_x = -(e.x - 200);
-          setTimeout(() => {
-            this.bossFocus = false;
-          }, 1600);
-        }
+        this.tryStartBossIntro(e);
       }
+    });
+  }
+
+  tryStartBossIntro(e) {
+    if (this.character.x > e.x - 600) {
+      e.startIntro();
+      this.bossBar.visible = true;
+      this.bossBar.setPercentage(e.hp / e.maxHp * 100);
+      this.bossFocus = true;
+      this.camera_x = -(e.x - 200);
+      setTimeout(() => this.bossFocus = false, 1600);
     }
   }
 
@@ -167,24 +172,38 @@ checkCollisions(){
 
 draw() {
   if(this.isStopped) return;
-  this.ctx.clearRect(0,0,this.canvas.width,this.canvas.height);
+  this.clearCanvas();
   const cam = Math.round(this.camera_x);
   this.ctx.translate(cam,0);
+  this.drawScene(cam);
+  this.ctx.translate(-cam,0);
+  requestAnimationFrame(()=>this.draw());
+}
+
+clearCanvas(){
+  this.ctx.clearRect(0,0,this.canvas.width,this.canvas.height);
+}
+
+drawScene(cam){
   this.addObjectsToMap(this.level.backgroundObjects);
   this.ctx.translate(-cam,0);
+  this.drawUI();
+  this.ctx.translate(cam,0);
+  this.drawEntities();
+}
+
+drawUI(){
   this.addToMap(this.statusBar);
   this.addToMap(this.bottleBar);
-  if (this.bossBar.visible) {
-    this.addToMap(this.bossBar);
-  }
-  this.ctx.translate(cam,0);
+  if (this.bossBar.visible) this.addToMap(this.bossBar);
+}
+
+drawEntities(){
   this.addToMap(this.character);
   this.addObjectsToMap(this.level.clouds);
   this.addObjectsToMap(this.level.bottles);
   this.addObjectsToMap(this.level.enemies);
   this.addObjectsToMap(this.throwableObjects);
-  this.ctx.translate(-cam,0);
-  requestAnimationFrame(()=>this.draw());
 }
 
 addObjectsToMap(objs){


### PR DESCRIPTION
## Summary
- Break up character animation logic into smaller functions for movement, input handling, and animation state
- Split world collision, boss intro, and rendering routines into focused helper methods

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fb3f1428832596ae039838230b2b